### PR TITLE
Fixing mocking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,3 +70,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation "org.junit.platform:junit-platform-engine:${junitPlatformVersion}"
 }
+kotlin {
+    experimental {
+        coroutines "enable"
+    }
+}

--- a/app/src/main/kotlin/org/spekframework/speksample/ApiClient.kt
+++ b/app/src/main/kotlin/org/spekframework/speksample/ApiClient.kt
@@ -60,16 +60,16 @@ private fun Call<*>.registerOnCompletion(continuation: CancellableContinuation<*
 }
 
 sealed class Result<out T : Any> {
-    class Successful<out T : Any>(val response: T) : Result<T>() {
+    data class Successful<out T : Any>(val response: T) : Result<T>() {
         override fun toString() = "Result.Ok{value=$response}"
     }
 
-    class Error(val apiError: String) : Result<Nothing>() {
+    data class Error(val apiError: String) : Result<Nothing>() {
         override fun toString() = "Result.Error{exception=$apiError}"
     }
 }
 
-inline fun <T : Any, R: Any> Result<T>.map(transform: (T) -> R): Result<R> {
+fun <T : Any, R: Any> Result<T>.map(transform: (T) -> R): Result<R> {
     return when(this) {
         is Result.Successful -> Result.Successful(transform(response))
         is Result.Error -> this

--- a/app/src/test/kotlin/org/spekframework/speksample/RepositoryTest.kt
+++ b/app/src/test/kotlin/org/spekframework/speksample/RepositoryTest.kt
@@ -1,5 +1,6 @@
 package org.spekframework.speksample
 
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.staticMockk
@@ -19,21 +20,21 @@ object RepositoryTest : Spek({
     val apiClient: ApiClient = mockk()
     val call: Call<UserDto> = mockk()
     val userDto: UserDto = mockk()
-    val resultDto: Result<UserDto> = mockk()
 
     val repository: Repository = Repository(apiClient)
     val expectedResult = User("name")
 
-    on("login"){
+    on("login") {
 
         it("should return user object") {
 
-            staticMockk("org.spekframework.speksample.ApiClientKt").use {
+            staticMockk("org.spekframework.speksample.ApiClientKt",
+                    "org.spekframework.speksample.RepositoryKt").use {
+
                 every { apiClient.getUser(any()) } returns call
-                every {
-                    runBlocking {
-                        call.awaitResult()
-                    }
+
+                coEvery {
+                    call.awaitResult()
                 } returns Result.Successful(UserDto("name"))
 
                 every {
@@ -41,7 +42,8 @@ object RepositoryTest : Spek({
                 } returns User("name")
 
                 every {
-                    resultDto.map { it.toDomain() }
+                    Result.Successful(UserDto("name"))
+                            .map(invoke<(UserDto) -> User, User, UserDto>(userDto))
                 } returns Result.Successful(User("name"))
 
                 runBlocking {


### PR DESCRIPTION
Mocking lambda expressions may be hard! You do need understand the low level details.

So here are few things to notice:
1. Extension functions are just functions with first argument $reciever$. So basically for mockk it's an eq() matcher over receiver.
2. There few things you can do with lambda: capture, invoke or skip
3. Inline methods are not mockable due to early stage inlining in Kotlin compiler
4. Keep track of objects you are mocking/returning. Note that eq matcher requires equals thus need `data` class
5. Don't forget to put all the staticMocks in the scope